### PR TITLE
Add a cache to reduce DB operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.6.1"
 rlp = { git = "https://github.com/CodeChain-io/rlp.git", version = "0.4" }
 rlp_derive = { git = "https://github.com/CodeChain-io/rlp.git", version = "0.2" }
 snap = "0.2"
+lru-cache = "0.1.2"
 
 [dev-dependencies]
 kvdb = "0.1"


### PR DESCRIPTION
 I implemented the cache in our Merkle trie using the `lru_cache` crate that used in CodeChain.

I found that performance improved by up to 30 percent when reading the value from the trie. However, when writing the value to the trie, there was no change in performance.

The key(address)-value(rlp_node) is stored in the cache when they are written, read in the DB. Before DB operation(`get()`), we can find the value in the cache. Therefore, the overhead derived from DB operations will be reduced by adding cache.

I used `RefCell` because of an error `'self' is a '&' reference, so the data it refers to cannot be borrowed as mutable`