### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
       - run: cargo fetch --verbose
       - run: cargo build
       - run: cargo test --verbose --all


### PR DESCRIPTION
The container for OS X doesn't have a cargo. It should use the toolchain
action.